### PR TITLE
Exclude directory from indexing

### DIFF
--- a/experiment_dirs
+++ b/experiment_dirs
@@ -60,4 +60,9 @@ for group in $*; do
     esac
 done
 
+EXCLUSIONS=(/g/data/ik11/outputs/access-om2-01/01deg_jra55v140_iaf_cycle4_MWpert)
+for exclude in ${EXCLUSIONS[@]}; do
+    EXPT_DIRS=("${EXPT_DIRS[@]/$exclude}")
+done
+
 echo "${EXPT_DIRS[@]}"


### PR DESCRIPTION
Add a mechanism to exclude some directories from the indexing and use it to (temporarily, I hope) exclude one directory that has been making the indexing fail.