### PR TITLE
Temporarily exclude one directory that has a problematic file

### DIFF
--- a/experiment_dirs
+++ b/experiment_dirs
@@ -60,7 +60,7 @@ for group in $*; do
     esac
 done
 
-EXCLUSIONS=( )
+EXCLUSIONS=(/g/data/ik11/outputs/access-om2-01/basal_melt_outputs)
 for exclude in ${EXCLUSIONS[@]}; do
     EXPT_DIRS=("${EXPT_DIRS[@]/$exclude}")
 done


### PR DESCRIPTION
@aekiss Here is another directory that is making the update fail. This time because of the following file:
`
/g/data/ik11/outputs/access-om2-01/basal_melt_outputs/accessom2-GPC001/rregionocean.nc`

with the following error message:

```
Indexing experiment: basal_melt_outputs
Traceback (most recent call last):
  File "/g/data3/hh5/public/apps/miniconda3/envs/analysis3-22.07/bin/cosima_cookbook-update_db", line 33, in <module>
    sys.exit(load_entry_point('cosima-cookbook==0.7.3', 'console_scripts', 'cosima_cookbook-update_db')())
  File "/g/data/hh5/public/apps/miniconda3/envs/analysis3-22.07/lib/python3.9/site-packages/cosima_cookbook/database_update.py", line 29, in main
    cc.database.build_index(
  File "/g/data/hh5/public/apps/miniconda3/envs/analysis3-22.07/lib/python3.9/site-packages/cosima_cookbook/database.py", line 864, in build_index
    _prune_files(expt, session, files, delete=(prune == "delete"))
  File "/g/data/hh5/public/apps/miniconda3/envs/analysis3-22.07/lib/python3.9/site-packages/cosima_cookbook/database.py", line 895, in _prune_files
    oldids = [
  File "/g/data/hh5/public/apps/miniconda3/envs/analysis3-22.07/lib/python3.9/site-packages/cosima_cookbook/database.py", line 902, in <listcomp>
    if f.index_time < datetime.fromtimestamp(f.ncfile_path.stat().st_mtime)
  File "/g/data/hh5/public/apps/miniconda3/envs/analysis3-22.07/lib/python3.9/pathlib.py", line 1232, in stat
    return self._accessor.stat(self)
PermissionError: [Errno 13] Permission denied: '/g/data/ik11/outputs/access-om2-01/basal_melt_outputs/accessom2-GPC001/rregionocean.nc'
```

I suggest we exclude the directory while investigating what is going on with this file, so that we get an updated database over the weekend, as it's been now three weeks since the last successful update. This is assuming that there are no more issues...